### PR TITLE
[build] use correct variables from FindCUDA

### DIFF
--- a/cmake/FindcuBLAS.cmake
+++ b/cmake/FindcuBLAS.cmake
@@ -18,6 +18,7 @@
 #=========================================================================
 
 find_package(CUDA 10.0 REQUIRED)
+enable_language(CUDA)
 find_path(CUBLAS_INCLUDE_DIR "cublas_v2.h" HINTS ${CMAKE_CUDA_TOOLKIT_INCLUDE_DIRECTORIES})
 get_filename_component(SYCL_BINARY_DIR ${CMAKE_CXX_COMPILER} DIRECTORY)
 # the OpenCL include file from cuda is opencl 1.1 and it is not compatible with DPC++

--- a/cmake/FindcuBLAS.cmake
+++ b/cmake/FindcuBLAS.cmake
@@ -18,8 +18,6 @@
 #=========================================================================
 
 find_package(CUDA 10.0 REQUIRED)
-enable_language(CUDA)
-find_path(CUBLAS_INCLUDE_DIR "cublas_v2.h" HINTS ${CMAKE_CUDA_TOOLKIT_INCLUDE_DIRECTORIES})
 get_filename_component(SYCL_BINARY_DIR ${CMAKE_CXX_COMPILER} DIRECTORY)
 # the OpenCL include file from cuda is opencl 1.1 and it is not compatible with DPC++
 # the OpenCL include headers 1.2 onward is required. This is used to bypass NVIDIA OpenCL headers
@@ -28,8 +26,6 @@ HINTS
 ${OPENCL_INCLUDE_DIR}
 ${SYCL_BINARY_DIR}/../include/sycl/
 )
-find_library(CUBLAS_LIBRARY cublas)
-find_library(CUDA_DRIVER_LIBRARY cuda)
 # this is work around to avoid duplication half creation in both cuda and SYCL
 add_compile_definitions(CUDA_NO_HALF)
 
@@ -38,19 +34,19 @@ find_package(Threads REQUIRED)
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(cuBLAS
     REQUIRED_VARS
-        CUBLAS_INCLUDE_DIR
-        CUDA_INCLUDE_DIRS
-        CUBLAS_LIBRARY
+        CUDA_TOOLKIT_INCLUDE
+        CUDA_cublas_LIBRARY
         CUDA_LIBRARIES
-        CUDA_DRIVER_LIBRARY
+        CUDA_CUDA_LIBRARY
         OPENCL_INCLUDE_DIR
 )
+
 if(NOT TARGET ONEMKL::cuBLAS::cuBLAS)
   add_library(ONEMKL::cuBLAS::cuBLAS SHARED IMPORTED)
   set_target_properties(ONEMKL::cuBLAS::cuBLAS PROPERTIES
-      IMPORTED_LOCATION ${CUBLAS_LIBRARY}
-      INTERFACE_INCLUDE_DIRECTORIES "${OPENCL_INCLUDE_DIR};${CUDA_INCLUDE_DIRS}"
-      INTERFACE_LINK_LIBRARIES "Threads::Threads;${CUDA_DRIVER_LIBRARY};${CUDA_LIBRARIES}"
+      IMPORTED_LOCATION ${CUDA_cublas_LIBRARY}
+      INTERFACE_INCLUDE_DIRECTORIES "${OPENCL_INCLUDE_DIR};${CUDA_TOOLKIT_INCLUDE}"
+      INTERFACE_LINK_LIBRARIES "Threads::Threads;${CUDA_CUDA_LIBRARY};${CUDA_LIBRARIES}"
   )
 
 endif()


### PR DESCRIPTION
@vrpascuzzi could you please check if suggested changes will work with your CUDA installation?

For cuBLAS and cuRAND backends we don't really need CUDA compiler, so I'm looking for solution where we will require only CUDA libraries and header files but not compiler, and based on what I found in [FindCUDA](https://github.com/Kitware/CMake/blob/v3.13.0/Modules/FindCUDA.cmake) module they all should be found there.

I see in cmake documentation [FindCUDA](https://cmake.org/cmake/help/v3.13/module/FindCUDA.html) is marked as deprecated but the good replacement that won't require CUDA compiler and CUDA language as part of the project will be only in cmake 3.17 [FindCUDAToolkit](https://cmake.org/cmake/help/v3.20/module/FindCUDAToolkit.html#module:FindCUDAToolkit), so I'd propose keep using FindCUDA, and move to FindCUDAToolkit when we will update minimum cmake support to 3.17.